### PR TITLE
Add Git Worktrees Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,12 +5,18 @@
 const fs = require('fs');
 const path = require('path');
 
-module.exports = function getCurrentBranchName(p = process.cwd()) {
-  const gitHeadPath = `${p}/.git/HEAD`;
+module.exports = function getCurrentBranchName(p = process.cwd(), i = 0) {
+  if (i > 127) return false;
+  let gitHeadPath = '';
+  try {
+    gitHeadPath = `${fs.readFileSync(`${p}/.git`, 'utf-8').trim().replace('gitdir: ', '')}/HEAD`;
+  } catch {
+    gitHeadPath = `${p}/.git/HEAD`;
+  }
 
   return fs.existsSync(p) ?
       fs.existsSync(gitHeadPath) ?
           fs.readFileSync(gitHeadPath, 'utf-8').trim().split('/')[2] :
-          getCurrentBranchName(path.resolve(p, '..')) :
+          getCurrentBranchName(path.resolve(p, '..'), i++) :
       false
 };


### PR DESCRIPTION
If directory is a git worktree, `.git` file references the base `.git` folder. We attempt to open `.git` file and find `HEAD` using that. If it fails, we fall back to attempting to open `.git/HEAD` and walk backwards to root directory.